### PR TITLE
Dark Mode Fixes

### DIFF
--- a/pretixSCAN.xcodeproj/project.pbxproj
+++ b/pretixSCAN.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		DC66800122CA09A0002EF1C1 /* FMDBQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC66800022CA09A0002EF1C1 /* FMDBQuestion.swift */; };
 		DC7DD5C322846B0B00C08817 /* ErrorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7DD5C222846B0B00C08817 /* ErrorMessage.swift */; };
 		DC7DD5C52285816D00C08817 /* SubEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7DD5C42285816D00C08817 /* SubEvent.swift */; };
+		DC82A5D523785FCB00F0650F /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC82A5D423785FCB00F0650F /* Colors.xcassets */; };
 		DC8387BF2317AB9D001C9434 /* FMDBDataStoreMigrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8387BE2317AB9D001C9434 /* FMDBDataStoreMigrations.swift */; };
 		DC8467A7225B99590013F647 /* DataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8467A6225B99590013F647 /* DataStore.swift */; };
 		DC8467AA225B99A50013F647 /* SyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8467A9225B99A50013F647 /* SyncManager.swift */; };
@@ -237,6 +238,7 @@
 		DC66800022CA09A0002EF1C1 /* FMDBQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FMDBQuestion.swift; sourceTree = "<group>"; };
 		DC7DD5C222846B0B00C08817 /* ErrorMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessage.swift; sourceTree = "<group>"; };
 		DC7DD5C42285816D00C08817 /* SubEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubEvent.swift; sourceTree = "<group>"; };
+		DC82A5D423785FCB00F0650F /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		DC8387BE2317AB9D001C9434 /* FMDBDataStoreMigrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FMDBDataStoreMigrations.swift; sourceTree = "<group>"; };
 		DC8467A6225B99590013F647 /* DataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStore.swift; sourceTree = "<group>"; };
 		DC8467A9225B99A50013F647 /* SyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncManager.swift; sourceTree = "<group>"; };
@@ -383,6 +385,7 @@
 				DC2F49FE2256669100710EFA /* Settings */,
 				DC227F282253A58E00314448 /* UIView Subclasses */,
 				DC07358022392476008326F7 /* Assets.xcassets */,
+				DC82A5D423785FCB00F0650F /* Colors.xcassets */,
 				DCB35B8B2248E8D400860385 /* fa-solid-900.ttf */,
 				DC07358522392476008326F7 /* Info.plist */,
 				DCDD82CA224AB1A400DC0200 /* Icon.swift */,
@@ -783,6 +786,7 @@
 				DC07358122392476008326F7 /* Assets.xcassets in Resources */,
 				DCAAFF29223929B60059C000 /* README.md in Resources */,
 				DC07357F22392474008326F7 /* Main.storyboard in Resources */,
+				DC82A5D523785FCB00F0650F /* Colors.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/pretixSCAN/Color.swift
+++ b/pretixSCAN/Color.swift
@@ -13,11 +13,18 @@ struct Color {
     static let primaryText = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
     static let secondary = #colorLiteral(red: 0.4978353977, green: 0.3521931767, blue: 0.567596674, alpha: 1)
     static let grayBackground = #colorLiteral(red: 0.972464025, green: 0.9726033807, blue: 0.9724336267, alpha: 1)
-    static let whiteBackground = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
     static let error = #colorLiteral(red: 0.8258044124, green: 0.3749413788, blue: 0.3758454323, alpha: 1)
     static let warning = #colorLiteral(red: 0.9982002378, green: 0.7056498528, blue: 0.1012035981, alpha: 1)
     static let okay = #colorLiteral(red: 0.3154402673, green: 0.6320772767, blue: 0.4040964842, alpha: 1)
     static let buttons = #colorLiteral(red: 0.4978353977, green: 0.3521931767, blue: 0.567596674, alpha: 1)
+
+    static var defaultBackground: UIColor {
+        if #available(iOS 13.0, *) {
+            return UIColor.systemBackground
+        } else {
+            return UIColor.white
+        }
+    }
 }
 
 struct Style {

--- a/pretixSCAN/Color.swift
+++ b/pretixSCAN/Color.swift
@@ -9,14 +9,14 @@
 import UIKit
 
 struct Color {
-    static let primary = #colorLiteral(red: 0.2312644422, green: 0.1089703217, blue: 0.2912759185, alpha: 1)
-    static let primaryText = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
-    static let secondary = #colorLiteral(red: 0.4978353977, green: 0.3521931767, blue: 0.567596674, alpha: 1)
-    static let grayBackground = #colorLiteral(red: 0.972464025, green: 0.9726033807, blue: 0.9724336267, alpha: 1)
-    static let error = #colorLiteral(red: 0.8258044124, green: 0.3749413788, blue: 0.3758454323, alpha: 1)
-    static let warning = #colorLiteral(red: 0.9982002378, green: 0.7056498528, blue: 0.1012035981, alpha: 1)
-    static let okay = #colorLiteral(red: 0.3154402673, green: 0.6320772767, blue: 0.4040964842, alpha: 1)
-    static let buttons = #colorLiteral(red: 0.4978353977, green: 0.3521931767, blue: 0.567596674, alpha: 1)
+    static let primary = UIColor(named: "primary")!
+    static let primaryText = UIColor(named: "primaryText")!
+    static let secondary = UIColor(named: "secondary")!
+    static let grayBackground = UIColor(named: "grayBackground")!
+    static let error = UIColor(named: "error")!
+    static let warning = UIColor(named: "warning")!
+    static let okay = UIColor(named: "okay")!
+    static let buttons = UIColor(named: "buttons")!
 
     static var defaultBackground: UIColor {
         if #available(iOS 13.0, *) {

--- a/pretixSCAN/Colors.xcassets/Contents.json
+++ b/pretixSCAN/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/pretixSCAN/Colors.xcassets/buttons.colorset/Contents.json
+++ b/pretixSCAN/Colors.xcassets/buttons.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.498",
+          "alpha" : "1.000",
+          "blue" : "0.568",
+          "green" : "0.352"
+        }
+      }
+    }
+  ]
+}

--- a/pretixSCAN/Colors.xcassets/error.colorset/Contents.json
+++ b/pretixSCAN/Colors.xcassets/error.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.826",
+          "alpha" : "1.000",
+          "blue" : "0.376",
+          "green" : "0.375"
+        }
+      }
+    }
+  ]
+}

--- a/pretixSCAN/Colors.xcassets/grayBackground.colorset/Contents.json
+++ b/pretixSCAN/Colors.xcassets/grayBackground.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.972",
+          "alpha" : "1.000",
+          "blue" : "0.972",
+          "green" : "0.973"
+        }
+      }
+    }
+  ]
+}

--- a/pretixSCAN/Colors.xcassets/grayBackground.colorset/Contents.json
+++ b/pretixSCAN/Colors.xcassets/grayBackground.colorset/Contents.json
@@ -15,6 +15,24 @@
           "green" : "0.973"
         }
       }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.200",
+          "alpha" : "1.000",
+          "blue" : "0.200",
+          "green" : "0.200"
+        }
+      }
     }
   ]
 }

--- a/pretixSCAN/Colors.xcassets/okay.colorset/Contents.json
+++ b/pretixSCAN/Colors.xcassets/okay.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.315",
+          "alpha" : "1.000",
+          "blue" : "0.404",
+          "green" : "0.632"
+        }
+      }
+    }
+  ]
+}

--- a/pretixSCAN/Colors.xcassets/primary.colorset/Contents.json
+++ b/pretixSCAN/Colors.xcassets/primary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.231",
+          "alpha" : "1.000",
+          "blue" : "0.291",
+          "green" : "0.109"
+        }
+      }
+    }
+  ]
+}

--- a/pretixSCAN/Colors.xcassets/primaryText.colorset/Contents.json
+++ b/pretixSCAN/Colors.xcassets/primaryText.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "1.000",
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/pretixSCAN/Colors.xcassets/secondary.colorset/Contents.json
+++ b/pretixSCAN/Colors.xcassets/secondary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.498",
+          "alpha" : "1.000",
+          "blue" : "0.568",
+          "green" : "0.352"
+        }
+      }
+    }
+  ]
+}

--- a/pretixSCAN/Colors.xcassets/warning.colorset/Contents.json
+++ b/pretixSCAN/Colors.xcassets/warning.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.998",
+          "alpha" : "1.000",
+          "blue" : "0.101",
+          "green" : "0.706"
+        }
+      }
+    }
+  ]
+}

--- a/pretixSCAN/Ticket Scanning/QuestionCells/QuestionCell.swift
+++ b/pretixSCAN/Ticket Scanning/QuestionCells/QuestionCell.swift
@@ -76,7 +76,7 @@ class QuestionCell: UITableViewCell {
         questionTextLabel.text = question?.question.representation(in: Locale.current)
 
         UIView.animate(withDuration: 0.25) {
-            self.backgroundColor = self.shouldStandOut ? Color.warning : Color.whiteBackground
+            self.backgroundColor = self.shouldStandOut ? Color.warning : Color.defaultBackground
         }
     }
 }


### PR DESCRIPTION
Dark Mode comes with iOS 13 and every new build enables it. Since we use a lot of default controls, most of the system works as expected, so this PR just has to clean up a few edge cases. 

In this PR we:

- **Move Color definitions into an Asset Catalog.** This allows us to provide easy color alternatives for Dark Mode 
- **Provide a Dark Mode enabled system background color.** This fixes a display issue in Questions cells where there was white text on white background.
- **Provide a Dark Mode color for `grayBackground`**, which fixes a display issue in search where the notice was white on very light gray background. The alternative color is instead a very dark background.
